### PR TITLE
Fix for `no_std` environments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![cfg(feature = "std")]
+#[cfg(feature = "std")]
 #[macro_use]
 extern crate std;
 


### PR DESCRIPTION
There was a superfluous exclamation mark which prevented me from building it in an embedded environment. It should be fine now. Thanks again for making this, I think it's going to be quite useful!