### PR TITLE
Support nostd for tests.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,8 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D clippy::all
       - name: Test
         run: cargo test --verbose
+      - name: Test nostd
+        run: cargo test --no-default-features
   release:
     runs-on: ubuntu-latest
     needs: [test]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 name = "wmidi"
 readme = "README.md"
 repository = "https://github.com/RustAudio/wmidi"
-version = "4.0.8"
+version = "4.0.9"
 
 [lib]
 # Required to pass flags to criterion benchmark.

--- a/src/byte.rs
+++ b/src/byte.rs
@@ -11,6 +11,16 @@ impl U7 {
     /// The maximum value for a u7 data byte.
     pub const MAX: U7 = U7(0x80 - 0x01);
 
+    /// Create a new `U7` or return an error if it is out of range.
+    #[inline(always)]
+    pub fn new(data: u8) -> Result<U7, Error> {
+        if data > u8::from(U7::MAX) {
+            Err(Error::DataByteOutOfRange)
+        } else {
+            Ok(U7(data))
+        }
+    }
+
     /// Convert a `u8` into a `U7` without bounds checking.
     ///
     /// # Safety
@@ -65,11 +75,7 @@ impl TryFrom<u8> for U7 {
 
     #[inline(always)]
     fn try_from(data: u8) -> Result<U7, Error> {
-        if data > u8::from(U7::MAX) {
-            Err(Error::DataByteOutOfRange)
-        } else {
-            Ok(U7(data))
-        }
+        U7::new(data)
     }
 }
 
@@ -158,7 +164,7 @@ mod tests {
 
     #[test]
     fn try_from_out_of_range_fails() {
-        for n in 0x80..=std::u8::MAX {
+        for n in 0x80..=u8::MAX {
             assert_eq!(U7::try_from(n), Err(Error::DataByteOutOfRange));
         }
     }
@@ -204,7 +210,7 @@ mod tests {
 
     #[test]
     fn try_from_out_of_range_16_fails() {
-        for n in 0x4000..=std::u16::MAX {
+        for n in 0x4000..=u16::MAX {
             assert_eq!(U14::try_from(n), Err(Error::U14OutOfRange));
         }
     }

--- a/src/cc.rs
+++ b/src/cc.rs
@@ -393,12 +393,11 @@ impl From<ControlFunction> for u8 {
 mod test {
     use super::*;
     use crate::U7;
-    use std::convert::TryFrom;
 
     #[test]
     fn from_u7() {
         for value in 0..128 {
-            let data = U7::try_from(value).unwrap();
+            let data = U7::new(value).unwrap();
             let cc = ControlFunction::from(data);
             assert_eq!(value, cc.into());
         }

--- a/src/midi_message.rs
+++ b/src/midi_message.rs
@@ -630,8 +630,9 @@ mod test {
         assert_eq!(b, [0xF0, 10, 20, 30, 40, 50, 0xF7, 0]);
     }
 
+    #[cfg(feature = "std")]
     #[test]
-    fn drop_unowned_sysex() {
+    fn drop_unowned_sysex_with_std() {
         assert_eq!(
             MidiMessage::SysEx(U7::try_from_bytes(&[1, 2, 3]).unwrap()).drop_unowned_sysex(),
             None
@@ -655,6 +656,19 @@ mod test {
         );
     }
 
+    #[test]
+    fn drop_unowned_sysex_with_nostd() {
+        assert_eq!(
+            MidiMessage::SysEx(U7::try_from_bytes(&[1, 2, 3]).unwrap()).drop_unowned_sysex(),
+            None
+        );
+        assert_eq!(
+            MidiMessage::TuneRequest.drop_unowned_sysex(),
+            Some(MidiMessage::TuneRequest)
+        );
+    }
+
+    #[cfg(feature = "std")]
     #[test]
     fn to_owned() {
         assert_eq!(

--- a/src/note.rs
+++ b/src/note.rs
@@ -482,6 +482,7 @@ impl fmt::Display for Note {
 mod test {
     use super::*;
 
+    #[cfg(feature = "std")]
     #[test]
     fn note_to_frequency() {
         let a440_f64 = Note::A4.to_freq_f64();


### PR DESCRIPTION
Some tests relied on std features which broke when running with nostd. Resolved by adding a nostd alternative to `TryFrom` and tagging vec reliant code to not run on nostd.

Fixes #16 