### PR TITLE
add basic defmt support with feature gate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ version = "4.0.10"
 bench = false
 
 [dependencies]
+defmt = { version = "0.3.5", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
@@ -23,6 +24,7 @@ criterion = "0.3"
 # Meta-features:
 default = ["std"] # Without "std", wmidi uses libcore.
 std = []
+defmt-03 = ["dep:defmt"]
 
 [[bench]]
 harness = false

--- a/src/byte.rs
+++ b/src/byte.rs
@@ -2,6 +2,7 @@ use crate::Error;
 use core::convert::TryFrom;
 
 /// A data byte that holds 7 bits of information.
+#[cfg_attr(feature="defmt-03", derive(defmt::Format))]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct U7(pub(crate) u8);
 
@@ -80,6 +81,7 @@ impl TryFrom<u8> for U7 {
 }
 
 /// A combination of 2 data bytes that holds 14 bits of information.
+#[cfg_attr(feature="defmt-03", derive(defmt::Format))]
 #[derive(Copy, Clone, Debug, Default, Eq, Hash, PartialEq, PartialOrd, Ord)]
 pub struct U14(u16);
 

--- a/src/cc.rs
+++ b/src/cc.rs
@@ -28,6 +28,7 @@ use crate::byte::U7;
 ///
 /// Channel mode messages affect the entire instrument and
 /// are only valid when sent over the instrument's "basic channel".
+#[cfg_attr(feature="defmt-03", derive(defmt::Format))]
 #[derive(Copy, Clone, Debug, Hash, Eq, PartialEq, PartialOrd, Ord)]
 pub struct ControlFunction(pub U7);
 

--- a/src/midi_message.rs
+++ b/src/midi_message.rs
@@ -5,6 +5,7 @@ use core::convert::TryFrom;
 use std::{io, vec::Vec};
 
 /// Holds information based on the Midi 1.0 spec.
+#[cfg_attr(feature="defmt-03", derive(defmt::Format))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum MidiMessage<'a> {
     /// This message is sent when a note is released (ended).
@@ -398,6 +399,7 @@ pub type Song = U7;
 
 /// The MIDI channel. There are 16 channels. They are numbered between 1 and 16
 /// inclusive, or indexed between 0 and 15 inclusive.
+#[cfg_attr(feature="defmt-03", derive(defmt::Format))]
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Channel {
     Ch1,

--- a/src/note.rs
+++ b/src/note.rs
@@ -16,6 +16,7 @@ use core::fmt;
 /// assert_eq!(Note::from_u8_lossy(48), Note::C3);
 /// ```
 #[repr(u8)]
+#[cfg_attr(feature="defmt-03", derive(defmt::Format))]
 #[derive(Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Note {
     CMinus1 = 0,


### PR DESCRIPTION
Hi there,

Thanks for your awesome work on this crate :) I'm using this in a project and wanted to be able to debug via `defmt-rtt` so I've added the derive attributes to support that. 

Let me know if there is anything you'd like changed, or if you don't want this feature at all (though I think it's useful for no_std work).