### PR TITLE
Use error from core

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ fn midi_to_bytes(message: wmidi::MidiMessage<'_>) -> Vec<u8> {
 
 ## Changelog
 
+### Unreleased
+
+* Use `error` from `core`.
+
 ### 4.0.0
 
 * New ControlFunction type which simply wraps a U7.

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,5 @@
+use core::error;
 use core::fmt;
-#[cfg(feature = "std")]
-use std::error;
 
 /// Midi decoding errors.
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
@@ -40,7 +39,6 @@ pub enum FromBytesError {
     U14OutOfRange,
 }
 
-#[cfg(feature = "std")]
 impl error::Error for FromBytesError {}
 
 impl fmt::Display for FromBytesError {
@@ -56,7 +54,6 @@ pub enum ToSliceError {
     BufferTooSmall,
 }
 
-#[cfg(feature = "std")]
 impl error::Error for ToSliceError {}
 
 impl fmt::Display for ToSliceError {


### PR DESCRIPTION
The error trait is available in core since 1.81 which is sometimes useful with `no_std`.