### PR TITLE
Add set_channel function for MidiMessage

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ fn midi_to_bytes(message: wmidi::MidiMessage<'_>) -> Vec<u8> {
 ### Unreleased
 
 * Use `error` from `core`.
+* Added `MidiMessage::set_channel()` method.
 
 ### 4.0.0
 

--- a/src/midi_message.rs
+++ b/src/midi_message.rs
@@ -339,6 +339,20 @@ impl<'a> MidiMessage<'a> {
         }
     }
 
+    /// Set the channel of the MIDI message, if applicable for the message type.
+    pub fn set_channel(&mut self, channel: Channel) {
+        match self {
+            MidiMessage::NoteOff(c, ..) => *c = channel,
+            MidiMessage::NoteOn(c, ..) => *c = channel,
+            MidiMessage::PolyphonicKeyPressure(c, ..) => *c = channel,
+            MidiMessage::ControlChange(c, ..) => *c = channel,
+            MidiMessage::ProgramChange(c, ..) => *c = channel,
+            MidiMessage::ChannelPressure(c, ..) => *c = channel,
+            MidiMessage::PitchBendChange(c, ..) => *c = channel,
+            _ => {}
+        }
+    }
+
     #[inline(always)]
     fn new_sysex(bytes: &'a [u8]) -> Result<Self, Error> {
         debug_assert!(bytes[0] == 0xF0);
@@ -697,5 +711,16 @@ mod test {
             Some(Channel::Ch8)
         );
         assert_eq!(MidiMessage::Start.channel(), None);
+    }
+
+    #[test]
+    fn set_channel() {
+        let mut msg = MidiMessage::ControlChange(
+            Channel::Ch8,
+            ControlFunction::DAMPER_PEDAL,
+            U7::try_from(55).unwrap(),
+        );
+        msg.set_channel(Channel::Ch9);
+        assert_eq!(msg.channel(), Some(Channel::Ch9));
     }
 }


### PR DESCRIPTION
The ability to separately set the channel for a message is useful when processing messages for routing or creating layered sounds. 

Ideally, the method would return a result with an error in case of system messages, but that would require a new dedicated error type. I'm not sure if it's worth do implement this.