### PR TITLE
Remove release from CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,17 +32,4 @@ jobs:
         run: cargo test --verbose
       - name: Test nostd
         run: cargo test --no-default-features
-  release:
-    runs-on: ubuntu-latest
-    needs: [unit_tests]
-    if: contains('refs/heads/main', github.ref)
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v2
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v1
-      - name: Publish
-        uses: katyo/publish-crates@v1
-        continue-on-error: true
-        with:
-          registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+


### PR DESCRIPTION
- It doesn't work due to token no longer being valid
  - Will not set up again as release is easy anyways